### PR TITLE
Proposing to remove spaces as base64 is generating spaces which is br…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ kubectl -n kube-system create secret tls k8s-gcr-quickfix-tls \
   --cert=server.crt \
   --key=server.key \
 
-CA=$(cat ca.crt | base64 )
+CA=$(base64 ca.crt | tr '\n' ' ' | sed 's/ //g')
 
 echo
 echo ">> MutatingWebhookConfiguration caBundle: $CA"


### PR DESCRIPTION
…eaking the install.sh script. 
Tested on ubuntu 22.04 amd64
This is a really cool implentation of a mutating webhook, lifesaver if we are unable to update things the "normal" way.
I went to test it and it fails on the install.sh script at the sed command, when I echo out the env var it has spaces in it, I think base64 is doing that. The following change removes spaces and allows the sed to replace `REPLACEME` with `$CA`. 